### PR TITLE
Getpass implementation

### DIFF
--- a/BiCrypt.py
+++ b/BiCrypt.py
@@ -15,12 +15,13 @@
 """Encrypt files with two different keys"""
 
 import argparse
+from getpass import getpass
 import os
 from hashlib import sha256
 import pyaes
 
 
-def img_encrypt(f1, f_password, s_password):
+def img_encrypt(f1, f_password=None, s_password=None):
     """Encrypt the file"""
     with open('%s.crypt' % f1, 'wb') as file1:
         with open(f1, 'rb') as file2:
@@ -49,7 +50,7 @@ def img_encrypt(f1, f_password, s_password):
                 file1.write(bytes(joined_encrypted_bytes))
 
 
-def img_decrypt(f1, f_password, s_password):
+def img_decrypt(f1, f_password=None, s_password=None):
     """Decrypt the file"""
     with open(f1, 'rb') as file1:
         file1_content = file1.read()
@@ -73,19 +74,50 @@ def img_decrypt(f1, f_password, s_password):
             file2.write(bytes(joined_decrypt_bytes))
 
 
+def get_passwords():
+    while True:
+        f_password = getpass(prompt='1st Password: ')
+
+        if args.safe:
+            f_password_c = getpass(prompt='Confirm 1st Password: ')
+
+            if f_password != f_password_c:
+                print('Passwords don\'t match')
+                continue
+
+        s_password = getpass(prompt='2nd Password: ')
+
+        if args.safe:
+            s_password_c = getpass(prompt='Confirm 2nd Password: ')
+
+            if s_password != s_password_c:
+                print('Passwords don\'t match')
+                continue
+
+        break
+
+    return [f_password, s_password]
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="""Encrypt and decrypt files
                                      with odd and even bytes
                                      """)
     parser.add_argument('file', metavar='File', help='File to encrypt',
                         type=str)
-    parser.add_argument('first_password', metavar='FirstPassphrase',
+    parser.add_argument('-f', '--first_password', metavar='FirstPassphrase',
                         help='first secret password,', type=str)
-    parser.add_argument('second_password', metavar='SecondPassphrase',
+    parser.add_argument('-s', '--second_password', metavar='SecondPassphrase',
                         help='second secret password,', type=str)
     parser.add_argument('-d', '--decrypt', dest='decrypt',
                         help='Decrypt file', action='store_true')
+    parser.add_argument('-ns', '--nosafety', dest='safe',
+                        help='Disable Password Confirmation (UNSAFE)',
+                        action='store_false')
     args = parser.parse_args()
+
+if args.first_password is None and args.second_password is None:
+    args.first_password, args.second_password = get_passwords()
 
 if args.decrypt:
     img_decrypt(args.file, args.first_password, args.second_password)

--- a/README.md
+++ b/README.md
@@ -25,21 +25,23 @@ For encrypt you file you will need to provied **two** passphrase and a file. Is 
 The syntax in command line is:
 
 ```
-python BiCrypt.py FileName FirstPassphrase SecondPassphrase
+python BiCrypt.py [-f FirstPassphrase -s SecondPassphrase] [-ns] 
 ```
 
 When you do that, the program generate a new file called 
 `YOU_FILE_NAME.crypt` which is no more that you encrypted file.
 
+If you do not provide both passwords, the tool will prompt you for your passwords. The `-ns` flag is to turn off password confirmation (ie. Only enter each password once and no checking, UNSAFE)
+
 For decrypt the file would be:
 
 ```
-python BiCrypt.py FileName.crypt FirstPassphrase SecondPassphrase
+python BiCrypt.py -d [-f FirstPassphrase -s SecondPassphrase] [-ns] 
 ```
 
 **Note** that you need to put yours passphrases in order, that is, just in the order as you put them when you encrypted the file, to can decrypt the file with sucess.
 
-Also yo can append `#!/usr/bin/env python` to the header on `BiCrypt.py` 
+Also you can append `#!/usr/bin/env python` to the header on `BiCrypt.py` 
 file, delete the file type (BiCrypt ~~.py~~), and then put that file in 
 you `/usr/bin` folder for avoid use the whole `python` command.
 


### PR DESCRIPTION
Implemented the getpass library to prompt the user for passwords. This means they do not have to type their passwords in plaintext in the command line. Provides a `-ns` flag, which allows them to turn off password confirmation, which is on by default for safety. 